### PR TITLE
fix: resolve problem of ESOCKETTIMEDOUT

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+network-timeout 600000


### PR DESCRIPTION
## 内容
GitHub Actionsのbuildがyarn install時にESOCKETTIMEDOUTで落ちている問題を解決するために、.yarnrcを配置する

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
https://github.com/yarnpkg/yarn/issues/6115#issuecomment-406623932

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
